### PR TITLE
Added the App name to the window title

### DIFF
--- a/toga/interface/app.py
+++ b/toga/interface/app.py
@@ -52,7 +52,7 @@ class App(object):
 
     def startup(self):
         '''Create and show the main window for the application'''
-        self.main_window = self._MAIN_WINDOW_CLASS()
+        self.main_window = self._MAIN_WINDOW_CLASS(self.name)
         self.main_window.app = self
 
         if self._startup_method:


### PR DESCRIPTION
In osx, the App name is not populated to the window title.

If I understood correctly the code, this also happens in linux, but I only tested OS X (and iOS just in case I break something). toga-win32 has a different implementation and it is probably that this little patch does not solve anything there.

The simple app I used to test:

```
import toga


def build(app):
    return toga.Box()

if __name__ == '__main__':
    APP = toga.App('My Library', 'org.pybee.mylibrary', startup=build)
    APP.main_loop()
```
